### PR TITLE
Slight changes to README's formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Parse HEX colors to [tui-rs](https://github.com/fdehau/tui-rs)'s [Rgb](https://d
 ## Example
 
 <span style="color: #C3F111">`#C3F111`</span> -> `Color::Rgb(195,241,17)`
+
 <span style="color: #CFB">`#CFB`</span> -> `Color::Rgb(204,255,187)`
+
 <span style="color: #AFAF00">`142`</span> -> `Color::Indexed(142)`  
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sruct ColorStruct {
     optional_color: Option<tui::style::Color>,
 }
 
-let color_text =  r###"{ "color" : "#12FC1C", "optional_color" : "#123" }"###
+let color_text =  r###"{ "color" : "#12FC1C", "optional_color" : "123" }"###
 let t: ColorStruct = serde_json::from_str::<ColorStruct>(color_text).unwrap();
 
 let c = ColorStruct {

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Color -> Tui
+# Color -> TUI
 
 [![build](https://img.shields.io/drone/build/uttarayan/color-to-tui?server=https%3A%2F%2Fdrone.uttarayan.me)][color-to-tui]
 [![build](https://github.com/uttarayan21/color-to-tui/actions/workflows/build.yaml/badge.svg)][mirror]  
 
+Parse HEX colors to [tui-rs](https://github.com/fdehau/tui-rs)'s [Rgb](https://docs.rs/tui/0.16.0/tui/style/enum.Color.html) colors.
 
-Parse hex colors to tui rgb colors  
+## Example
 
-<span style="color: #c3f111">`#c3f111`</span> -> `Color::Rgb(195,241,17)`
+<span style="color: #C3F111">`#C3F111`</span> -> `Color::Rgb(195,241,17)`
+<span style="color: #CFB">`#CFB`</span> -> `Color::Rgb(204,255,187)`
+<span style="color: #AFAF00">`142`</span> -> `Color::Indexed(142)`  
 
-Note that the indexed colors are **NOT HEX**  
-<span style="color: #afaf00">`#142`</span> -> `Color::Indexed(142)`  
-
-Example
+## Usage
 
 ```rust
 #[derive(Serialize, Deserialize, PartialEq)]
@@ -31,9 +31,7 @@ let c = ColorStruct {
 };
 
 assert_eq!(t, c);
-
 ```
-
 
 [color-to-tui]: https://git.uttarayan.me/uttarayan/color-to-tui
 [mirror]: https://github.com/uttarayan21/color-to-tui

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ Parse HEX colors to [tui-rs](https://github.com/fdehau/tui-rs)' [Rgb](https://do
 
 ## Example
 
-<span style="color: #C3F111">`#C3F111`</span> -> `Color::Rgb(195,241,17)`
-
-<span style="color: #CFB">`#CFB`</span> -> `Color::Rgb(204,255,187)`
-
-<span style="color: #AFAF00">`142`</span> -> `Color::Indexed(142)`  
+- `#C3F111` -> `Color::Rgb(195,241,17)`
+- `#CFB` -> `Color::Rgb(204,255,187)`
+- `142` -> `Color::Indexed(142)`  
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://img.shields.io/drone/build/uttarayan/color-to-tui?server=https%3A%2F%2Fdrone.uttarayan.me)][color-to-tui]
 [![build](https://github.com/uttarayan21/color-to-tui/actions/workflows/build.yaml/badge.svg)][mirror]  
 
-Parse HEX colors to [tui-rs](https://github.com/fdehau/tui-rs)'s [Rgb](https://docs.rs/tui/0.16.0/tui/style/enum.Color.html) colors.
+Parse HEX colors to [tui-rs](https://github.com/fdehau/tui-rs)' [Rgb](https://docs.rs/tui/0.16.0/tui/style/enum.Color.html) colors.
 
 ## Example
 


### PR DESCRIPTION
[Check me out.](https://github.com/grtcdr/color-parser-tui/blob/master/README.md)

- I linked to **tui-rs** and the `Rgb` enum in case someone wandering the interwebs has no idea what TUI or RGB means.
- I also added a shorthand hex color example.
> Note: the span has no effect on the formatting.