### PR TITLE
Bump `tui` dependency to v0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [".drone.yml", ".github/*"]
 
 [dependencies]
 serde = { version = "1.0.130", features = ["derive"] }
-tui = { version = "0.16.0", default-features = false }
+tui = { version = "0.18.0", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.68"


### PR DESCRIPTION
Hey, Uttarayan :)

I recently tried to bump all of macchina's dependencies and wasn't able to do so because this crate has an older version. This PR, like the title suggests, bumps `tui` to its latest version.