### PR TITLE
Move from `tui-rs` to `ratatui`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color-to-tui"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Uttarayan Mondal <uttarayan21@gmail.com>"]
 edition = "2021"
 description = "Parse colors and convert them to ratatui::style::Colors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "color-to-tui"
 version = "0.2.0"
 authors = ["Uttarayan Mondal <uttarayan21@gmail.com>"]
 edition = "2021"
-description = "Parse colors and convert them to tui::style::Colors"
+description = "Parse colors and convert them to ratatui::style::Colors"
 homepage = "https://git.uttarayan.me/uttarayan/color-to-tui"
 repository = "https://git.uttarayan.me/uttarayan/color-to-tui"
 license = "MIT"
@@ -13,7 +13,7 @@ exclude = [".drone.yml", ".github/*"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-tui = { version = "0.*", default-features = false }
+tui = { package="ratatui", version = "0.*", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.68"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://img.shields.io/drone/build/uttarayan/color-to-tui?server=https%3A%2F%2Fdrone.uttarayan.me)][color-to-tui]
 [![build](https://github.com/uttarayan21/color-to-tui/actions/workflows/build.yaml/badge.svg)][mirror]  
 
-Parse HEX colors to [tui-rs](https://github.com/fdehau/tui-rs)' [Rgb](https://docs.rs/tui/0.16.0/tui/style/enum.Color.html) colors.
+Parse HEX colors to [ratatui](https://github.com/tui-rs-revival/ratatui)'s [Rgb](https://docs.rs/ratatui/latest/ratatui/style/enum.Color.html) colors.
 
 ## Example
 
@@ -17,9 +17,9 @@ Parse HEX colors to [tui-rs](https://github.com/fdehau/tui-rs)' [Rgb](https://do
 #[derive(Serialize, Deserialize, PartialEq)]
 sruct ColorStruct {
     #[serde(with = "color_to_tui"]
-    color: tui::style::Color,
+    color: ratatui::style::Color,
     #[serde(with = "color_to_tui::optional"]
-    optional_color: Option<tui::style::Color>,
+    optional_color: Option<ratatui::style::Color>,
 }
 
 let color_text =  r###"{ "color" : "#12FC1C", "optional_color" : "123" }"###


### PR DESCRIPTION
Since tui-rs is currently [unmaintained](https://github.com/fdehau/tui-rs/issues/654), it might make sense to move to its most probable successor [ratatui](https://github.com/tui-rs-revival/ratatui).